### PR TITLE
Issue/#18 build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
-        fail-fast: false
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11-dev']
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v3
 
@@ -23,14 +23,14 @@ jobs:
       uses: jpetrucciani/mypy-check@0.761
       with:
         path: 'src'
-    
+
   build:
     needs: [check]
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11-dev']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -46,12 +46,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry
-    
+
     - name: Install dependencies
       run: |
         poetry install
         poetry check
-    
+
     - name: Build package
       run: |
         poetry build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
       uses: lgeiger/black-action@v1.0.1
       with:
         args: ". --check"
+      if: ${{ matrix.operating-system }} == 'ubuntu-latest'
     - name: Mypy Check
       uses: jpetrucciani/mypy-check@0.761
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Black Code Formatter
       uses: lgeiger/black-action@v1.0.1
@@ -35,10 +35,10 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,24 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
 
+    - name: Black Code Formatter
+      uses: lgeiger/black-action@v1.0.1
+      with:
+        args: ". --check"
+
+    - name: Mypy Check
+      uses: jpetrucciani/mypy-check@0.761
+      with:
+        path: 'src'
+    
+  build:
+    needs: [check]
     strategy:
       fail-fast: false
       matrix:
@@ -20,28 +36,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Black Code Formatter
-      uses: lgeiger/black-action@v1.0.1
-      with:
-        args: ". --check"
-      if: runner.os == 'Linux'
-    - name: Mypy Check
-      uses: jpetrucciani/mypy-check@0.761
-      with:
-        path: 'src'
-      if: runner.os == 'Linux'
+
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry
+    
     - name: Install dependencies
       run: |
         poetry install
         poetry check
+    
     - name: Build package
       run: |
         poetry build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       uses: lgeiger/black-action@v1.0.1
       with:
         args: ". --check"
-      if: ${{ matrix.operating-system }} == 'ubuntu-latest'
+      if: runner.os == 'Linux'
     - name: Mypy Check
       uses: jpetrucciani/mypy-check@0.761
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        fail-fast: false
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -32,6 +33,7 @@ jobs:
       uses: jpetrucciani/mypy-check@0.761
       with:
         path: 'src'
+      if: runner.os == 'Linux'
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11-dev']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11-dev']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Solution for #18 

- Build is run on all versions of Python for:
  - `ubuntu-latest`
  - `windows-latest`
  - `macos-latest`

To update the `build` job to use all operating systems, the `Black Code Formatter` and `Mypy Check` actions were moved to a job named `check`.  This was needed because these actions require a Linux-based runner.

The `build` job was updated to require `check` to pass before starting.

This prevents having to skip the `Black Code Formatter` and `Mypy Check` actions in the `build` job for `windows-latest` and `macos-latest` while allowing all `build` jobs to benefit from the checks.

